### PR TITLE
Prepping for gtsummary v2.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 .Ruserdata
+.DS_Store

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Depends:
     R (>= 4.1.0),
     emmeans,
     ggformula,
-    gtsummary,
+    gtsummary (>= 1.9.9),
     huxtable,
     magrittr,
     stats
@@ -40,6 +40,7 @@ Imports:
     tidyselect
 Suggests:
     broom,
+    cardx,
     effectsize,
     ggeffects,
     ggfortify,
@@ -62,6 +63,7 @@ Suggests:
     see,
     sjPlot,
     tidyverse
+Remotes: ddsjoberg/gtsummary, insightsengineering/cardx
 License: GPL-2
 Encoding: UTF-8
 LazyData: true

--- a/R/misc_functions.R
+++ b/R/misc_functions.R
@@ -485,7 +485,7 @@ cosm_reg <- function(gt_tbl, pad = 3, type = 3, bold = TRUE, head_label = "**Var
   if (is.null(type)) {
     tbl <- tbl0
   } else {
-    tbl <- tbl0 %>% gtsummary::add_global_p(type = type, quiet = TRUE)
+    tbl <- tbl0 %>% gtsummary::add_global_p(type = type)
   }
 
   if (bold == FALSE) {


### PR DESCRIPTION
Hello! I am preparing the release of gtsummary v2.0, and saw a small change was needed in pubh. I've made that change, and you should be ready to make a pubh release after the gtsummary release in about 3 weeks. After gtsummary has made its release, you can remove the `Remotes:` field I've added to your DESCRIPTION file.

All the best, 
Daniel